### PR TITLE
Add attestation verification feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ $ gh extension install k1LoW/gh-setup
         # checksum: f1ee97bbf22d5324ec2b468d83f43088d9e5c61deb77fafc220b297e03d47574
         # force: true
         # strict: true
+        # verify-attestation: true
+        # attestation-flags: "--digest-alg sha256 --cert-identity example.com"
         # gh-setup-version: latest
       -
         name: Run tbls
@@ -165,3 +167,27 @@ $ go install github.com/k1LoW/gh-setup/cmd/gh-setup@latest
 ```console
 $ docker pull ghcr.io/k1low/gh-setup:latest
 ```
+
+## Attestation Verification
+
+gh-setup supports verifying attestations using the `gh attestation verify` command. To enable attestation verification, use the `--verify-attestation` flag. You can also pass additional flags to the `gh attestation verify` command using the `--attestation-flags` flag.
+
+Example:
+
+```console
+$ gh setup --repo k1LoW/tbls --verify-attestation --attestation-flags "--owner=k1LoW"
+```
+
+In GitHub Actions:
+
+```yaml
+- name: Setup k1LoW/tbls
+  uses: k1LoW/gh-setup@v1
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    repo: k1LoW/tbls
+    verify-attestation: true
+    attestation-flags: "--owner=k1LoW"
+```
+
+This feature requires the `gh` CLI with the attestation extension to be installed.

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,14 @@ inputs:
     description: "Skip check content-type of assets"
     default: ""
     required: false
+  verify-attestation:
+    description: "Enable attestation verification using 'gh attestation verify'"
+    default: ""
+    required: false
+  attestation-flags:
+    description: "Additional flags to pass to 'gh attestation verify'"
+    default: ""
+    required: false
   gh-setup-version:
     description: "Version of gh-setup"
     default: "v1.10.2"
@@ -81,4 +89,6 @@ runs:
         GH_SETUP_FORCE: ${{ inputs.force }}
         GH_SETUP_STRICT: ${{ inputs.strict }}
         GH_SETUP_SKIP_CONTENT_TYPE_CHECK: ${{ inputs.skip-content-type-check }}
+        GH_SETUP_VERIFY_ATTESTATION: ${{ inputs.verify-attestation }}
+        GH_SETUP_ATTESTATION_FLAGS: ${{ inputs.attestation-flags }}
         GH_SETUP_BIN: ${{ steps.install-gh-setup.outputs.bin }}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,4 +122,6 @@ func init() {
 	rootCmd.Flags().BoolVarP(&opt.Strict, "strict", "", false, "require strict match")
 	rootCmd.Flags().BoolVarP(&opt.SkipContentTypeCheck, "skip-content-type-check", "", false, "skip check content-type of assets")
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "", false, "show verbose log")
+	rootCmd.Flags().BoolVarP(&opt.VerifyAttestation, "verify-attestation", "", false, "enable attestation verification using 'gh attestation verify'")
+	rootCmd.Flags().StringVarP(&opt.AttestationFlags, "attestation-flags", "", "", "additional flags to pass to 'gh attestation verify' (e.g. \"--owner=k1LoW\")")
 }

--- a/scripts/run-gh-setup.sh
+++ b/scripts/run-gh-setup.sh
@@ -19,6 +19,8 @@ checksum=${GH_SETUP_CHECKSUM}
 force=${GH_SETUP_FORCE}
 strict=${GH_SETUP_STRICT}
 skip_content_type_check=${GH_SETUP_SKIP_CONTENT_TYPE_CHECK}
+verify_attestation=${GH_SETUP_VERIFY_ATTESTATION}
+attestation_flags=${GH_SETUP_ATTESTATION_FLAGS}
 
 boolopts=""
 
@@ -34,4 +36,13 @@ if [ ! -z "${skip_content_type_check}" ]; then
     boolopts+=" --skip-content-type-check"
 fi
 
-${bin} --repo ${repo} --version=${version} --os=${os} --arch=${arch} --match=${match} --bin-dir=${bin_dir} --bin-match=${bin_match} --checksum=${checksum}${boolopts}
+if [ ! -z "${verify_attestation}" ]; then
+    boolopts+=" --verify-attestation"
+fi
+
+attestation_flags_opt=""
+if [ ! -z "${attestation_flags}" ]; then
+    attestation_flags_opt=" --attestation-flags=\"${attestation_flags}\""
+fi
+
+${bin} --repo ${repo} --version=${version} --os=${os} --arch=${arch} --match=${match} --bin-dir=${bin_dir} --bin-match=${bin_match} --checksum=${checksum}${boolopts}${attestation_flags_opt}


### PR DESCRIPTION
I thought it would be useful if gh setup could verify attestations using 'gh attestation verify' when installing tools. This PR adds that capability.\n\nWith this feature, users can:\n- Enable attestation verification with the '--verify-attestation' flag\n- Pass additional flags to 'gh attestation verify' using the '--attestation-flags' option\n\nI've implemented this feature and it seems to work well, but I'd appreciate your feedback on the approach and implementation.